### PR TITLE
Changes default keybinding back to C-y

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -44,7 +44,7 @@
     "commands": {
         "_execute_browser_action": {
             "suggested_key": {
-                "default": "Alt+Shift+J"
+                "default": "Ctrl+Y"
             }
         }
     },


### PR DESCRIPTION
The keybinding is working well for me in Firefox 53; it should work in Firefox 52 and up (released any day now). This restores the default behavior before the webextension.